### PR TITLE
Clear Content + Undo Clear Button

### DIFF
--- a/__tests__/Speednote.test.tsx
+++ b/__tests__/Speednote.test.tsx
@@ -7,8 +7,44 @@ import userEvent from '@testing-library/user-event';
 
 import Home from '@/app/page';
 
+beforeEach(() => {
+  // Prevent unexpected values on tests. `localStorage` can persist through tests!
+  window.localStorage.clear();
+});
+
+const assertEditor = () => {
+  const [title, content, clearContentButton, undoClearButton] = [
+    screen.getByRole('textbox', { name: 'Note title' }),
+    screen.getByRole('textbox', { name: 'Note content' }),
+    screen.getByRole('button', { name: 'Clear content' }),
+    screen.queryByRole('button', { name: 'Undo clear' }), // This is not supposed to be there on the first render.
+  ];
+
+  expect(title).toBeInTheDocument();
+  expect(content).toBeInTheDocument();
+  expect(clearContentButton).toBeInTheDocument();
+  expect(undoClearButton).not.toBeInTheDocument(); // This is not supposed to be in the DOM on the first render.
+
+  // We only want the title and the content and nothing else in the DOM.
+  const inputs = screen.getAllByRole('textbox');
+  expect(inputs).toHaveLength(2);
+
+  // `undoClearButton` is not returned because we'd rather do the query again when we want to test it. The current state
+  // of the `undoClearButton` here will be stale by the time we wanted to do tests against it.
+  return { title, content, clearContentButton };
+};
+
+const renderWithProviders = () => {
+  const user = userEvent.setup();
+
+  return {
+    user,
+    ...render(<Home />),
+  };
+};
+
 test('renders properly', async () => {
-  render(<Home />);
+  renderWithProviders();
 
   // Wait for the editor to load or else it'll cause an `act` warning due
   // to the dynamic import not loading the editor yet.
@@ -17,15 +53,10 @@ test('renders properly', async () => {
   ).toBeInTheDocument();
   await waitForElementToBeRemoved(screen.queryByRole('progressbar'));
 
-  // Assert all inputs exist.
-  expect(
-    screen.getByRole('textbox', { name: 'Note title' })
-  ).toBeInTheDocument();
-  expect(
-    screen.getByRole('textbox', { name: 'Note content' })
-  ).toBeInTheDocument();
+  // Assert the editor.
+  assertEditor();
 
-  // Sanity checks for markups.
+  // Sanity checks for markups, check footer and header.
   expect(screen.getByText('About')).toBeInTheDocument();
   expect(
     screen.getByText(
@@ -44,20 +75,12 @@ test('renders properly', async () => {
 });
 
 test('able to edit title and content', async () => {
-  const user = userEvent.setup();
-  render(<Home />);
+  const { user } = renderWithProviders();
 
   // Presumption of why we don't have the await for progressbar here: We don't need to wait
   // for the editor to load as it has already been loaded and cached (dynamic import occurs before we
   // render the `Home` component).
-  const inputs = screen.getAllByRole('textbox');
-  expect(inputs).toHaveLength(2); // Title and content.
-
-  const title = screen.getByRole('textbox', { name: 'Note title' });
-  expect(title).toBeInTheDocument();
-
-  const content = screen.getByRole('textbox', { name: 'Note content' });
-  expect(content).toBeInTheDocument();
+  const { title, content } = assertEditor();
 
   // Type at both inputs, make sure that both have changes.
   await user.type(title, 'Expenses as of 25 May 2023');

--- a/__tests__/Speednote.test.tsx
+++ b/__tests__/Speednote.test.tsx
@@ -96,3 +96,23 @@ test('able to edit title and content', async () => {
   // There should be a date that shows the last updated date as well.
   expect(screen.getByText(/Last updated at/i)).toBeInTheDocument();
 });
+
+test('able to clear content and undo clear', async () => {
+  const { user } = renderWithProviders();
+
+  const { content, clearContentButton } = assertEditor();
+  await user.type(content, "Tears Don't Fall, Enchanted, Beautiful Trauma");
+  expect(content).not.toHaveValue('');
+  expect(content).toHaveValue("Tears Don't Fall, Enchanted, Beautiful Trauma");
+
+  expect(clearContentButton).toBeEnabled();
+  await user.click(clearContentButton);
+  expect(content).toHaveValue('');
+
+  // Query the `undoClearButton` again here.
+  const undoClearButton = screen.getByRole('button', { name: 'Undo clear' });
+  expect(undoClearButton).toBeInTheDocument();
+  expect(undoClearButton).toBeEnabled();
+  await user.click(undoClearButton);
+  expect(content).toHaveValue("Tears Don't Fall, Enchanted, Beautiful Trauma");
+});

--- a/app/Editor.module.css
+++ b/app/Editor.module.css
@@ -29,3 +29,7 @@
   transform: scale(1.05);
   box-shadow: 0 1rem 4rem rgba(0, 0, 0, 0.25);
 }
+
+.button:last-of-type:not(:first-of-type) {
+  margin-left: 0.5rem;
+}

--- a/app/Editor.module.css
+++ b/app/Editor.module.css
@@ -7,3 +7,25 @@
   font-weight: 600;
   color: var(--time);
 }
+
+.button {
+  border: none;
+  color: var(--thanks);
+  font-size: inherit;
+  border-bottom: 1px solid currentColor;
+  padding-bottom: 2px;
+  display: inline-block;
+  background-color: transparent;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.button:hover {
+  color: var(--time);
+}
+
+.button:focus {
+  outline: none;
+  transform: scale(1.05);
+  box-shadow: 0 1rem 4rem rgba(0, 0, 0, 0.25);
+}

--- a/app/Editor.tsx
+++ b/app/Editor.tsx
@@ -100,6 +100,18 @@ const Editor = () => {
           }}
         />
       </section>
+
+      <section className={styles.section}>
+        <button
+          className={styles.button}
+          onClick={() => {
+            setContent('');
+            storeContent('');
+          }}
+        >
+          Clear content
+        </button>
+      </section>
     </>
   );
 };

--- a/app/Editor.tsx
+++ b/app/Editor.tsx
@@ -12,10 +12,6 @@ const isValidTimestamp = (timestamp: string) => {
 };
 
 const displayReadableTime = (timestamp: string) => {
-  if (!isValidTimestamp(timestamp)) {
-    return '';
-  }
-
   // Falls back to the browser's settings.
   const parsedTimestamp = new Date(Number.parseInt(timestamp, 10));
   return Intl.DateTimeFormat(undefined, {

--- a/app/Editor.tsx
+++ b/app/Editor.tsx
@@ -16,6 +16,7 @@ const displayReadableTime = (timestamp: string) => {
     return '';
   }
 
+  // Falls back to the browser's settings.
   const parsedTimestamp = new Date(Number.parseInt(timestamp, 10));
   return Intl.DateTimeFormat(undefined, {
     dateStyle: 'full',
@@ -36,7 +37,6 @@ const Editor = () => {
   const [title, setTitle] = useState(notes.title);
   const [content, setContent] = useState(notes.content);
   const [lastUpdated, setLastUpdated] = useState(notes.lastUpdated);
-  const [isAutosaving, setIsAutosaving] = useState(false);
 
   const debouncedChangeTitle = useDebounce(() => storeTitle(title));
   const debouncedChangeContent = useDebounce(() => storeContent(content));
@@ -78,7 +78,6 @@ const Editor = () => {
           placeholder="Enter a title"
           value={title}
           onChange={({ currentTarget: { value } }) => {
-            setIsAutosaving(true);
             setTitle(value);
             setLastUpdated(Date.now().toString());
             debouncedChangeTitle();
@@ -94,7 +93,6 @@ const Editor = () => {
           placeholder="Start writing, your progress will be automatically stored in your machine's local storage"
           value={content}
           onChange={({ currentTarget: { value } }) => {
-            setIsAutosaving(true);
             setContent(value);
             setLastUpdated(Date.now().toString());
             debouncedChangeContent();

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,7 +7,7 @@ import type { ReactNode } from 'react';
 const inter = Inter({ subsets: ['latin'] });
 
 export const metadata: Metadata = {
-  title: 'Speednote',
+  title: 'Speednote — Quickly input your thoughts',
   description:
     'Speednote, as its name suggests, is an optimized PWA to quickly type notes as fast as possible. Put your thoughts here before you move them to another storage!',
   metadataBase: new URL('https://speednote.vercel.app'),

--- a/app/store.ts
+++ b/app/store.ts
@@ -28,10 +28,6 @@ const dataStore = {
   getLastUpdated: () => {
     return localStorage.getItem(storageKey.LAST_UPDATED_STORAGE_KEY);
   },
-
-  clear: () => {
-    return localStorage.clear();
-  },
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "jest --watchAll --verbose",
     "format-check": "prettier --check ./**/*.{ts,tsx}",
     "type-check": "tsc --noEmit",
-    "test-ci": "jest --ci --verbose",
+    "test-ci": "jest --ci --verbose --coverage",
     "quality-check": "yarn format-check && yarn lint && yarn type-check"
   },
   "dependencies": {


### PR DESCRIPTION
Changes:

- Get rid of `isAutosaving` prop remains.
- Add a button to reset the content of the note, and provide a classic styling.
- Update website title.
- Add a button to undo clear, and also provide a classic styling.
- Refactor: Add handler for `handleButtonClick`.
- Refactor: Test code for general editor assertions.
- Write test to clear content and undo clear.
- Check for coverage in CI tests.