### PR TITLE
Fallback Messages on Shared Notes

### DIFF
--- a/__tests__/Speednote.test.tsx
+++ b/__tests__/Speednote.test.tsx
@@ -272,14 +272,14 @@ test('able to copy shared note properly', async () => {
     'SSBmaW5pc2hlZCBhIHByb2plY3QgYW5kIHJlY2VpdmVkIDUwMDAgSlBZLg=='
   );
   await user.click(shareNoteButton);
+
+  const expectedUrl = `${window.location.href}?title=${expectedEncodedTitle}&content=${expectedEncodedContent}`;
   expect(mockWriteText).toHaveBeenCalledTimes(1);
-  expect(mockWriteText).toHaveBeenCalledWith(
-    `${window.origin}?title=${expectedEncodedTitle}&content=${expectedEncodedContent}`
-  );
+  expect(mockWriteText).toHaveBeenCalledWith(expectedUrl);
 });
 
 test('able to see shared URL properly', async () => {
-  const startUrl = `${window.origin}?title=SW5jb21l&content=SSBmaW5pc2hlZCBhIHByb2plY3QgYW5kIHJlY2VpdmVkIDUwMDAgSlBZLg%3D%3D`;
+  const startUrl = `${window.location.href}?title=SW5jb21l&content=SSBmaW5pc2hlZCBhIHByb2plY3QgYW5kIHJlY2VpdmVkIDUwMDAgSlBZLg%3D%3D`;
   const { user } = renderWithProviders(startUrl);
 
   const { title, content } = assertEditor();
@@ -315,6 +315,18 @@ test('able to see shared URL properly', async () => {
 
 test.each([
   {
+    name: 'valid title, but no content',
+    url: '?title=RW5jaGFudGVk',
+    expectedTitle: 'Enchanted',
+    expectedContent: 'No content in the shared note',
+  },
+  {
+    name: 'valid content, but no title',
+    url: '?content=QmVhdXRpZnVsIFRyYXVtYQ==',
+    expectedTitle: 'No title in the shared note',
+    expectedContent: 'Beautiful Trauma',
+  },
+  {
     name: 'invalid title and content',
     url: '?title=xxx&content=yyy',
     expectedTitle:
@@ -323,21 +335,21 @@ test.each([
       'Invalid content format from the shared URL, so we cannot read it for now. Please ask the other party to re-share the URL!',
   },
   {
-    name: 'title only',
+    name: 'invalid title only',
     url: '?title=xxx&content=QmVhdXRpZnVsIFRyYXVtYQ==',
     expectedTitle:
       'Invalid title format from the shared URL, so we cannot read it.',
     expectedContent: 'Beautiful Trauma',
   },
   {
-    name: 'content only',
+    name: 'invalid content only',
     url: '?title=RW5jaGFudGVk&content=123',
     expectedTitle: 'Enchanted',
     expectedContent:
       'Invalid content format from the shared URL, so we cannot read it for now. Please ask the other party to re-share the URL!',
   },
 ])(
-  'able to handle invalid format of shared note url ($name)',
+  'able to handle various formats of shared note url ($name)',
   async ({ url, expectedTitle, expectedContent }) => {
     renderWithProviders(url);
 

--- a/app/Editor.tsx
+++ b/app/Editor.tsx
@@ -106,13 +106,13 @@ const Editor = () => {
     });
   };
 
-  const handleShareButtonClick = async () => {
+  const handleShareButtonClick = () => {
     // Invoke all debounces to make sure all of the states are in their final value.
     debouncedChangeTitle.flush();
     debouncedChangeContent.flush();
 
     // Set new query parameters.
-    const newSearchParams = new URLSearchParams(window.location.search);
+    const newSearchParams = new URLSearchParams();
     if (title !== '') {
       newSearchParams.set('title', window.btoa(title));
     }
@@ -122,8 +122,8 @@ const Editor = () => {
     }
 
     // Copy into the user's clipboard.
-    const url = `${window.location.origin}?${newSearchParams.toString()}`;
-    await navigator.clipboard.writeText(url);
+    const url = `${window.location.href}?${newSearchParams.toString()}`;
+    navigator.clipboard.writeText(url);
   };
 
   useEffect(() => {

--- a/app/schema.ts
+++ b/app/schema.ts
@@ -70,7 +70,11 @@ export const sharedNoteSchema = z.discriminatedUnion('isShared', [
       .string()
       .nullable()
       .transform((val) => {
-        if (!val || !BASE64_REGEX.test(val)) {
+        if (!val) {
+          return 'No title in the shared note';
+        }
+
+        if (!BASE64_REGEX.test(val)) {
           return 'Invalid title format from the shared URL, so we cannot read it.';
         }
 
@@ -80,7 +84,11 @@ export const sharedNoteSchema = z.discriminatedUnion('isShared', [
       .string()
       .nullable()
       .transform((val) => {
-        if (!val || !BASE64_REGEX.test(val)) {
+        if (!val) {
+          return 'No content in the shared note';
+        }
+
+        if (!BASE64_REGEX.test(val)) {
           return 'Invalid content format from the shared URL, so we cannot read it for now. Please ask the other party to re-share the URL!';
         }
 

--- a/e2e/Speednote.test.tsx
+++ b/e2e/Speednote.test.tsx
@@ -295,6 +295,18 @@ test('able to copy and see a shared note properly', async () => {
 // Playwright doesn't support Jest's `test.each`, so we have to use this looping workaround.
 const invalidFormatUrlTestCases = [
   {
+    name: 'valid title, but no content',
+    url: '?title=RW5jaGFudGVk',
+    expectedTitle: 'Enchanted',
+    expectedContent: 'No content in the shared note',
+  },
+  {
+    name: 'valid content, but no title',
+    url: '?content=QmVhdXRpZnVsIFRyYXVtYQ==',
+    expectedTitle: 'No title in the shared note',
+    expectedContent: 'Beautiful Trauma',
+  },
+  {
     name: 'invalid title and content',
     url: '?title=xxx&content=yyy',
     expectedTitle:
@@ -319,7 +331,7 @@ const invalidFormatUrlTestCases = [
 ];
 
 for (const { name, ...testCase } of invalidFormatUrlTestCases) {
-  test(`able to handle invalid format of shared note url (${name})`, async ({
+  test(`able to handle various format of shared note url (${name})`, async ({
     page,
   }) => {
     // Render the app with our new browser context.


### PR DESCRIPTION
Changes:

- Implements fallback messages on shared notes.
- Optimize search parameters (`new URLSearchParams()`) and the way of getting the current URL (`window.location.origin` to `window.location.href`).
- Try to remove `await` to fix a certain problem in an Android device. For some reason, this is browser dependent and different browsers can have different experiences and behaviors.
- Write more tests (both unit and integration) to capture the behavior of fallback messages.

Resolves #16.