### PR TITLE
Implement Unclearable Notes when Frozen

### DIFF
--- a/app/Button.module.scss
+++ b/app/Button.module.scss
@@ -9,6 +9,15 @@
   cursor: pointer;
   transition: all 0.2s;
 
+  &:disabled {
+    color: var(--time);
+    opacity: 0.25;
+
+    &:hover {
+      cursor: not-allowed;
+    }
+  }
+
   &:hover {
     color: var(--time);
   }

--- a/app/Editor.tsx
+++ b/app/Editor.tsx
@@ -210,23 +210,26 @@ const Editor = () => {
         )}
       </section>
 
-      <section className={styles.section}>
-        <Button onClick={handleContentActionButtonClick('clear')}>
-          Clear content
-        </Button>
+      {!sharedNote.isShared && (
+        <section className={styles.section}>
+          <Button
+            onClick={handleContentActionButtonClick('clear')}
+            disabled={frozen === 'true'}
+          >
+            Clear content
+          </Button>
 
-        {!sharedNote.isShared && (
           <Button onClick={handleFreezeButtonClick}>
             {frozen === 'true' ? 'Unfreeze note' : 'Freeze note'}
           </Button>
-        )}
 
-        {lastChanges && (
-          <Button onClick={handleContentActionButtonClick('undo')}>
-            Undo clear
-          </Button>
-        )}
-      </section>
+          {lastChanges && (
+            <Button onClick={handleContentActionButtonClick('undo')}>
+              Undo clear
+            </Button>
+          )}
+        </section>
+      )}
 
       <section className={styles.section}>
         {sharedNote.isShared && (


### PR DESCRIPTION
Changes:

- Adjust editor so that it shows the right editor when on a shared mode.
- Add `disabled` state in `Clear content`.
- Add more assertions to assert this behavior.
- Add `disabled` state styles for buttons.