### PR TITLE
Add `id` for `Editor`'s `Textarea`

### DIFF
--- a/app/Editor.tsx
+++ b/app/Editor.tsx
@@ -159,6 +159,7 @@ const Editor = () => {
       <section className={styles.section}>
         {sharedNote.isShared ? (
           <Input
+            id="note-title"
             aria-label="Note title"
             type="title"
             placeholder={sharedNote.title}
@@ -167,6 +168,7 @@ const Editor = () => {
           />
         ) : (
           <Input
+            id="note-title"
             aria-label="Note title"
             type="title"
             placeholder={'Enter a title'}
@@ -185,6 +187,7 @@ const Editor = () => {
       <section className={styles.section}>
         {sharedNote.isShared ? (
           <Input
+            id="note-content"
             aria-label="Note content"
             type="content"
             placeholder={sharedNote.content}
@@ -193,6 +196,7 @@ const Editor = () => {
           />
         ) : (
           <Input
+            id="note-content"
             aria-label="Note content"
             type="content"
             placeholder={

--- a/app/Input.tsx
+++ b/app/Input.tsx
@@ -12,16 +12,24 @@ import { type Data } from './schema';
 // We should use `ComponentPropsWithoutRef` to be explicit.
 // Reference: https://react-typescript-cheatsheet.netlify.app/docs/advanced/patterns_by_usecase/#definitely-not-reacthtmlprops-or-reacthtmlattributes
 type InputProps = {
+  id: string;
   type: 'title' | 'content';
   value: string;
   readOnly: Data['config']['frozen'];
   onChange?: (e: ChangeEvent<HTMLTextAreaElement>) => void;
 } & Omit<
   ComponentPropsWithoutRef<'textarea'>,
-  'style' | 'value' | 'onChange' | 'readOnly'
+  'id' | 'style' | 'value' | 'onChange' | 'readOnly'
 >;
 
-const Input = ({ type, value, readOnly, onChange, ...rest }: InputProps) => {
+const Input = ({
+  id,
+  type,
+  value,
+  readOnly,
+  onChange,
+  ...rest
+}: InputProps) => {
   const style = [
     styles.base,
     type === 'title' ? styles.title : styles.content,
@@ -30,6 +38,7 @@ const Input = ({ type, value, readOnly, onChange, ...rest }: InputProps) => {
 
   return (
     <TextareaAutosize
+      id={id}
       className={style}
       onChange={onChange}
       value={value}


### PR DESCRIPTION
Chrome DevTools reports that `id` does not exist in the `textarea` element, so I added it.