### PR TITLE
Single-Responsibility Principle for `SharedNote` and `NoteEditor`

### DIFF
--- a/app/use-shared-note.ts
+++ b/app/use-shared-note.ts
@@ -8,7 +8,7 @@ import { sharedNoteSchema } from './schema';
  *
  * @returns Shared note parsed data.
  */
-export const useSharedNoteQueryParams = () => {
+export const useSharedNote = () => {
   const searchParams = useSearchParams();
   const sharedTitle = searchParams.get('title');
   const sharedContent = searchParams.get('content');


### PR DESCRIPTION
Resolves a lot of confusion related to the states of `SharedNote` and `NoteEditor`. I have also adjusted the tests related to `Share note` button behavior so the behavior is not confusing. Quoting from the 26d5041129cd2ec5092def0dfbbdf7824e1ff815 description related to shared note:

> We should not be able to re-share the shared note to another person.
The button should be hidden as it is very confusing (which one to share?
is it our note or the shared note?) Conveying this message is difficult
to the users, so it's better to make it explicit and do not allow users
to re-share notes on a shared note (UI/UX problem).
>
> Perhaps asking them to just copy the URL bar would be much easier.

Resolves #27.