### PR TITLE
New Pages: `404 Not Found` and `Error`

### DIFF
--- a/app/error.module.scss
+++ b/app/error.module.scss
@@ -1,0 +1,18 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  gap: 12px;
+}
+
+.title {
+  font-size: 24px;
+  font-weight: 700;
+}
+
+.subtitle {
+  font-size: 16px;
+  font-weight: 500;
+}

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { memo } from 'react';
+
+import Button from './Button';
+import errorStyles from './error.module.scss';
+import Link from './Link';
+import pageStyles from './page.module.scss';
+
+type ErrorProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+const Error = ({ reset }: ErrorProps) => (
+  <>
+    <header className={pageStyles.header}>
+      <Link type="external" href="https://github.com/lauslim12/speednote">
+        About
+      </Link>
+    </header>
+
+    <main className={pageStyles.main}>
+      <section className={errorStyles.container}>
+        <h1 className={errorStyles.title}>Unexpected error</h1>
+        <h2 className={errorStyles.subtitle}>
+          This error is potentially caused by the local storage being disabled.
+          Please enable the local storage to use this application.
+        </h2>
+
+        <Button onClick={reset}>Try again</Button>
+      </section>
+    </main>
+
+    <footer className={pageStyles.footer}>
+      <p className={pageStyles.thanks}>
+        Thank you so much for using Speednote! Made with ♥ in Tokyo, Japan
+      </p>
+
+      <p className={pageStyles.hash}>{process.env.VERSION}</p>
+    </footer>
+  </>
+);
+
+export default memo(Error);

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,38 @@
+import { memo } from 'react';
+
+import errorStyles from './error.module.scss';
+import Link from './Link';
+import pageStyles from './page.module.scss';
+
+const NotFound = () => (
+  <>
+    <header className={pageStyles.header}>
+      <Link type="external" href="https://github.com/lauslim12/speednote">
+        About
+      </Link>
+    </header>
+
+    <main className={pageStyles.main}>
+      <section className={errorStyles.container}>
+        <h1 className={errorStyles.title}>Page not found</h1>
+        <h2 className={errorStyles.subtitle}>
+          Could not find the requested resource
+        </h2>
+
+        <Link type="internal" href="/">
+          Back to editor
+        </Link>
+      </section>
+    </main>
+
+    <footer className={pageStyles.footer}>
+      <p className={pageStyles.thanks}>
+        Thank you so much for using Speednote! Made with ♥ in Tokyo, Japan
+      </p>
+
+      <p className={pageStyles.hash}>{process.env.VERSION}</p>
+    </footer>
+  </>
+);
+
+export default memo(NotFound);

--- a/e2e/Speednote.test.tsx
+++ b/e2e/Speednote.test.tsx
@@ -378,3 +378,30 @@ test('able to handle unused query parameters', async ({ page }) => {
   await expect(title).toBeEditable();
   await expect(content).toBeEditable();
 });
+
+// 404 pages are only testable in integration environments as it's a server-side page.
+test('able to view and recover from 404 not found', async ({ page }) => {
+  await renderPage(page, '/404');
+
+  await expect(
+    page.getByRole('heading', { name: 'Page not found' })
+  ).toBeVisible();
+  await expect(
+    page.getByRole('heading', {
+      name: 'Could not find the requested resource',
+    })
+  ).toBeVisible();
+
+  const backToEditorLink = page.getByRole('link', { name: 'Back to editor' });
+  await expect(backToEditorLink).toBeVisible();
+  await backToEditorLink.click();
+
+  // Should be redirected back to the editor.
+  await page.waitForURL('/');
+  await expect(page).toHaveURL('/');
+
+  // Check the editor.
+  const { title, content } = await getAndAssertEditor(page);
+  await expect(title).toBeEditable();
+  await expect(content).toBeEditable();
+});


### PR DESCRIPTION
Gracefully handles `404 Not Found` as a server side page, and a catch-all handler for unexpected errors in Next.js (might be browser errors, or any other JavaScript/unexpected errors).