### PR TITLE
Utilize initializer pattern for `DataStore` and remove `memo`

### DIFF
--- a/app/Button.tsx
+++ b/app/Button.tsx
@@ -1,5 +1,4 @@
 import type { ComponentPropsWithoutRef, ReactNode } from 'react';
-import { memo } from 'react';
 
 import styles from './Button.module.scss';
 
@@ -13,4 +12,4 @@ const Button = ({ children, ...rest }: ButtonProps) => (
   </button>
 );
 
-export default memo(Button);
+export default Button;

--- a/app/Configuration.tsx
+++ b/app/Configuration.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { memo, useState } from 'react';
+import { useState } from 'react';
 
 import Button from './Button';
 
@@ -32,4 +32,4 @@ const Configuration = () => {
   );
 };
 
-export default memo(Configuration);
+export default Configuration;

--- a/app/Editor.tsx
+++ b/app/Editor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { type ChangeEvent, memo, useEffect, useState } from 'react';
+import { type ChangeEvent, useEffect, useState } from 'react';
 
 import Button from './Button';
 import styles from './Editor.module.scss';
@@ -252,4 +252,4 @@ const NoteEditor = ({ storage, initialValue }: NoteEditorProps) => {
   );
 };
 
-export default memo(Editor);
+export default Editor;

--- a/app/Input.tsx
+++ b/app/Input.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import type { ComponentPropsWithoutRef } from 'react';
-import { memo } from 'react';
 import TextareaAutosize from 'react-textarea-autosize';
 
 import styles from './Input.module.scss';
@@ -43,4 +42,4 @@ const Input = ({
   );
 };
 
-export default memo(Input);
+export default Input;

--- a/app/Link.tsx
+++ b/app/Link.tsx
@@ -1,6 +1,5 @@
 import NextLink, { type LinkProps as NextLinkProps } from 'next/link';
 import type { ComponentPropsWithoutRef, ReactNode } from 'react';
-import { memo } from 'react';
 
 import styles from './Link.module.scss';
 
@@ -39,4 +38,4 @@ const Link = ({ type, children, href, ...rest }: LinkProps) => {
   );
 };
 
-export default memo(Link);
+export default Link;

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import { memo } from 'react';
-
 import Button from './Button';
 import errorStyles from './error.module.scss';
 import Link from './Link';
@@ -42,4 +40,4 @@ const Error = ({ reset }: ErrorProps) => (
   </>
 );
 
-export default memo(Error);
+export default Error;

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,5 +1,3 @@
-import { memo } from 'react';
-
 import errorStyles from './error.module.scss';
 import Link from './Link';
 import pageStyles from './page.module.scss';
@@ -35,4 +33,4 @@ const NotFound = () => (
   </>
 );
 
-export default memo(NotFound);
+export default NotFound;

--- a/app/use-storage.ts
+++ b/app/use-storage.ts
@@ -47,7 +47,7 @@ const DataService = (storage: Storage): DataService => {
  * @returns The service provider.
  */
 export const useStorage = () => {
-  const [service] = useState(DataService(localStorage));
+  const [service] = useState(() => DataService(localStorage));
 
   return service;
 };


### PR DESCRIPTION
Optimizes the code a little bit by using the initializer pattern for `DataStore` (as it's a single object which returns the same functions and it will just use the same object reference even if the component re-renders) and removes `memo` as it's redundant. It's not useful to `memo` everything as everything has its own optimization cost and re-renders are cheap in React, especially the `Trigger` and `Render` phase, where React tries to find the diffs of the DOM.