### PR TITLE
Fix `Latin1` Encoding Errors, Support Kanji Characters in Note Sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ There are no dependencies (environment variables or the like), this is a standal
 
 ## Tests
 
-Because this project is still small, we can achieve a relatively high enough code coverage. There are two test libraries used in this project: React Testing Library and Playwright.
+Because this project is still small, we can achieve a relatively high enough code coverage. There are two test libraries used in this project: React Testing Library and Playwright. For some reason, if you run the Playwright tests locally without building (using the production version), the `404 Not Found` tests will fail. It is possible that this is caused by the development build.
 
 ```bash
 # To run RTL tests, do the commands below:

--- a/app/Editor.tsx
+++ b/app/Editor.tsx
@@ -36,39 +36,44 @@ type SharedNoteProps = {
   content: string;
 };
 
-const SharedNote = ({ title, content }: SharedNoteProps) => {
-  return (
-    <>
-      <section className={styles.section}>
-        <Input
-          id="note-title"
-          aria-label="Note title"
-          type="title"
-          placeholder={title}
-          value={title}
-          readOnly
-        />
-      </section>
+/**
+ * In this component, the `value` of the `title` and `content` has to be inserted into
+ * `decodeURIComponent` to prevent errors when sharing notes with Kanji characters, or any
+ * other characters outside of the `Latin1` range.
+ *
+ * {@link https://github.com/lauslim12/speednote/issues/36}
+ */
+const SharedNote = ({ title, content }: SharedNoteProps) => (
+  <>
+    <section className={styles.section}>
+      <Input
+        id="note-title"
+        aria-label="Note title"
+        type="title"
+        placeholder={title}
+        value={decodeURIComponent(title)}
+        readOnly
+      />
+    </section>
 
-      <section className={styles.section}>
-        <Input
-          id="note-content"
-          aria-label="Note content"
-          type="content"
-          placeholder={content}
-          value={content}
-          readOnly
-        />
-      </section>
+    <section className={styles.section}>
+      <Input
+        id="note-content"
+        aria-label="Note content"
+        type="content"
+        placeholder={content}
+        value={decodeURIComponent(content)}
+        readOnly
+      />
+    </section>
 
-      <section className={styles.section}>
-        <Link type="internal" href="/">
-          Return to your note
-        </Link>
-      </section>
-    </>
-  );
-};
+    <section className={styles.section}>
+      <Link type="internal" href="/">
+        Return to your note
+      </Link>
+    </section>
+  </>
+);
 
 const NoteEditorRoot = () => {
   const storage = useStorage();
@@ -226,14 +231,17 @@ const ExternalNoteAction = ({ onSave }: ActionBaseProps) => {
     // Save the note initially, so we're using the final state.
     onSave();
 
-    // Set new query parameters.
+    // Set new query parameters. Encode as URI component to prevent
+    // failure when sharing Kanji characters or any other characters
+    // that exist outside of the Latin1 range.
+    // Reference: https://github.com/lauslim12/speednote/issues/36.
     const newSearchParams = new URLSearchParams();
     if (title !== '') {
-      newSearchParams.set('title', window.btoa(title));
+      newSearchParams.set('title', window.btoa(encodeURIComponent(title)));
     }
 
     if (content !== '') {
-      newSearchParams.set('content', window.btoa(content));
+      newSearchParams.set('content', window.btoa(encodeURIComponent(content)));
     }
 
     // Copy the URL the user's clipboard. I know that the `writeText` is supposed


### PR DESCRIPTION
By wrapping the `title` and `content` in `encodeURIComponent` before sharing the note, and utilizing `decodeURIComponent` before displaying the shared note, this fixes the problem of trying to share notes with Kanji characters.

Added tests (both integration and end-to-end) to make sure that this behavior is working, with English, 日本語, and 中文.

Resolves #36.