### PR TITLE
Use `@fontsource-variable/inter` for a smaller bundle size

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "speednote",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@eslint/js": "^9.6.0",
-    "@fontsource/inter": "^5.0.18",
+    "@fontsource-variable/inter": "^5.0.20",
     "@playwright/test": "^1.43.1",
     "@solid-primitives/scheduled": "^1.4.3",
     "@solidjs/router": "^0.13.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,9 @@ importers:
       '@eslint/js':
         specifier: ^9.6.0
         version: 9.6.0
-      '@fontsource/inter':
-        specifier: ^5.0.18
-        version: 5.0.18
+      '@fontsource-variable/inter':
+        specifier: ^5.0.20
+        version: 5.0.20
       '@playwright/test':
         specifier: ^1.43.1
         version: 1.43.1
@@ -860,8 +860,8 @@ packages:
     resolution: {integrity: sha512-BsWiH1yFGjXXS2yvrf5LyuoSIIbPrGUWob917o+BTKuZ7qJdxX8aJLRxs1fS9n6r7vESrq1OUqb68dANcFXuQQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@fontsource/inter@5.0.18':
-    resolution: {integrity: sha512-YCsoYPTcs713sI7tLtxaPrIhXAXvEetGg5Ry02ivA8qUOb3fQHojbK/X9HLD5OOKvFUNR2Ynkwb1kR1hVKQHpw==}
+  '@fontsource-variable/inter@5.0.20':
+    resolution: {integrity: sha512-dhzG4Zls/tIrf8h0FhTNi8jT/uFwNhdTY2vKe6DYqoXDYOfEcTVZDyh1hKml1rlLT44Y7OoKoGz8w7czDW7twQ==}
 
   '@humanwhocodes/module-importer@1.0.1':
     resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
@@ -3236,10 +3236,6 @@ packages:
     peerDependencies:
       solid-js: ^1.3
 
-  source-map-js@1.0.2:
-    resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
-    engines: {node: '>=0.10.0'}
-
   source-map-js@1.2.0:
     resolution: {integrity: sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==}
     engines: {node: '>=0.10.0'}
@@ -4647,7 +4643,7 @@ snapshots:
 
   '@eslint/object-schema@2.1.4': {}
 
-  '@fontsource/inter@5.0.18': {}
+  '@fontsource-variable/inter@5.0.20': {}
 
   '@humanwhocodes/module-importer@1.0.1': {}
 
@@ -7423,7 +7419,7 @@ snapshots:
     dependencies:
       chokidar: 3.5.3
       immutable: 4.3.0
-      source-map-js: 1.0.2
+      source-map-js: 1.2.0
     optional: true
 
   saxes@6.0.0:
@@ -7495,9 +7491,6 @@ snapshots:
       '@babel/helper-module-imports': 7.24.3
       '@babel/types': 7.24.0
       solid-js: 1.8.17
-
-  source-map-js@1.0.2:
-    optional: true
 
   source-map-js@1.2.0: {}
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,4 @@
-import '@fontsource/inter/400.css';
-import '@fontsource/inter/600.css';
-import '@fontsource/inter/900.css';
+import '@fontsource-variable/inter';
 import './index.css';
 
 import { Route, Router } from '@solidjs/router';

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -6,9 +6,7 @@ export default {
   darkMode: ['selector'],
   theme: {
     fontFamily: {
-      sans: ['Inter', ...defaultTheme.fontFamily.sans],
-      serif: ['Inter', ...defaultTheme.fontFamily.serif],
-      mono: ['Inter', ...defaultTheme.fontFamily.mono],
+      sans: ['Inter Variable', ...defaultTheme.fontFamily.sans],
     },
     extend: {
       colors: {


### PR DESCRIPTION
Use the variable font from `@fontsource` to allow a smaller bundle size.