### PR TITLE
Better Padding in Mobile Screen Sizes

### DIFF
--- a/src/Editor.tsx
+++ b/src/Editor.tsx
@@ -51,7 +51,7 @@ type SharedNoteProps = {
  * {@link https://github.com/lauslim12/speednote/issues/36}
  */
 const SharedNote = ({ title, content }: SharedNoteProps) => (
-  <section class="flex flex-col gap-3 p-1 md:p-3">
+  <section class="flex flex-col gap-3 p-3 md:p-3">
     <section>
       <Input
         id="note-title"
@@ -228,7 +228,7 @@ const NoteEditor = (props: NoteEditorProps) => {
   };
 
   return (
-    <section class="flex flex-col gap-3 p-1 md:p-3">
+    <section class="flex flex-col gap-3 p-3 md:p-3">
       <section>
         <Metadata {...others} save={save} />
       </section>


### PR DESCRIPTION
It feels a bit "cramped" and "in your screen" even though it is already using `p-1`, so we're reverting it back to `p-3` (`12px`).