### PR TITLE
UI Refinements, Dark Mode Fixes, Test Flake Fixes

### DIFF
--- a/__tests__/Speednote.test.tsx
+++ b/__tests__/Speednote.test.tsx
@@ -120,13 +120,8 @@ test("renders properly", async () => {
 	await assertEditor();
 	assertHeader();
 
-	// Sanity checks for markups, check footer and header.
+	// Sanity checks for header.
 	expect(screen.getByText(/About/i)).toBeInTheDocument();
-	expect(
-		screen.getByText(
-			"Thank you so much for using Speednote! Made with ♥ in Tokyo, Japan",
-		),
-	).toBeInTheDocument();
 
 	// Should also render a link to GitHub.
 	const linkToSource = screen.getByRole("link", { name: /About/ });
@@ -178,8 +173,8 @@ test("able to edit title and content", async () => {
 		"Today I spent 1000 JPY for lunch at a fish shop",
 	);
 
-	// There should be a date that shows the last updated date as well.
-	expect(screen.getByText(/Last updated at/i)).toBeInTheDocument();
+	// There should be a timestamp showing when the note was last updated.
+	expect(screen.getByRole("note")).toBeInTheDocument();
 });
 
 test("able to clear content and undo clear", async () => {
@@ -195,14 +190,21 @@ test("able to clear content and undo clear", async () => {
 	});
 	expect(clearContentButton).toBeEnabled();
 	await user.click(clearContentButton);
-	expect(content).toHaveValue("");
 
-	// Query the `undoClearButton` again here.
-	const undoClearButton = screen.getByRole("button", { name: "Undo clear" });
-	expect(undoClearButton).toBeInTheDocument();
+	// findByRole waits for the re-render — both the empty content and the "Undo clear"
+	// button appearing are results of the same async click handler (handleClear).
+	const undoClearButton = await screen.findByRole("button", {
+		name: "Undo clear",
+	});
+	expect(content).toHaveValue("");
 	expect(undoClearButton).toBeEnabled();
+
 	await user.click(undoClearButton);
-	expect(content).toHaveValue("Tears Don't Fall, Enchanted, Beautiful Trauma");
+
+	// findByDisplayValue retries until handleUndo's state update has re-rendered the content.
+	await screen.findByDisplayValue(
+		"Tears Don't Fall, Enchanted, Beautiful Trauma",
+	);
 });
 
 test("able to switch color mode", async () => {
@@ -228,8 +230,11 @@ test("able to freeze notes and unfreeze them", async () => {
 	expect(freezeNoteButton).toBeEnabled();
 	await user.click(freezeNoteButton);
 
-	// Should have `readOnly` attribute.
-	expect(freezeNoteButton).toHaveAccessibleName("Unfreeze note");
+	// findByRole waits for the re-render, preventing a flake where the assertion
+	// runs before React processes the state update from the async click handler.
+	const unfreezeButton = await screen.findByRole("button", {
+		name: "Unfreeze note",
+	});
 	expect(title).toHaveAttribute("readOnly");
 	expect(content).toHaveAttribute("readOnly");
 
@@ -247,9 +252,9 @@ test("able to freeze notes and unfreeze them", async () => {
 	expect(clearContentButton).toBeDisabled();
 
 	// Unfreeze the note.
-	expect(freezeNoteButton).toBeEnabled();
-	await user.click(freezeNoteButton);
-	expect(freezeNoteButton).toHaveAccessibleName("Freeze note");
+	expect(unfreezeButton).toBeEnabled();
+	await user.click(unfreezeButton);
+	await screen.findByRole("button", { name: "Freeze note" });
 
 	// `Clear content` should not be disabled.
 	expect(clearContentButton).toBeEnabled();

--- a/app/app.tsx
+++ b/app/app.tsx
@@ -11,21 +11,20 @@ import { Header } from "~/header";
  * The GPU attempts to optimize by skipping the paint for the empty stretched area,
  * resulting in dead, uninitialized tiles that render as solid black horizontal bands.
  *
- * By explicitly declaring the background colors (`bg-gray-50 dark:bg-slate-950`)
+ * By explicitly declaring the background colors (`bg-gray-50 dark:bg-stone-900`)
  * on this flex container, we force the hardware compositor to paint the tiles,
  * bypassing the optimization glitch.
  */
 export const App = () => (
-	<div className="mx-auto flex min-h-screen max-w-7xl flex-col bg-gray-50 p-5 transition-colors duration-300 dark:bg-gray-950">
+	<div className="mx-auto flex min-h-screen max-w-7xl flex-col bg-gray-50 p-5 transition-colors duration-300 dark:bg-stone-900">
 		<Header />
 
-		<main className="flex flex-1 flex-col px-0 py-8 sm:px-2 md:px-6 lg:px-12 xl:px-20">
+		<main className="flex flex-1 flex-col px-0 py-8 sm:px-4 md:px-10 lg:px-20 xl:px-32">
 			<Editor />
 		</main>
 
-		<footer className="mt-auto text-center text-gray-500 text-xs transition-colors duration-300 dark:text-gray-600">
-			<p>Thank you so much for using Speednote! Made with ♥ in Tokyo, Japan</p>
-			<p className="mt-1.5 text-[0.5rem] opacity-60">
+		<footer className="mt-auto text-center text-[0.5rem] text-gray-400 opacity-60 transition-colors duration-300 dark:text-gray-600">
+			<p>
 				{import.meta.env.VITE_APP_VERSION} (
 				{import.meta.env.VITE_GIT_SHORT_SHA ?? "local"})
 			</p>

--- a/app/editor/note-editor.tsx
+++ b/app/editor/note-editor.tsx
@@ -21,26 +21,19 @@ const Metadata = () => {
 	}
 
 	const formattedTimestamp = Intl.DateTimeFormat(undefined, {
-		dateStyle: "full",
+		dateStyle: "long",
 		hourCycle: "h23",
-		timeStyle: "full",
+		timeStyle: "medium",
 	}).format(lastUpdated);
 
 	return (
 		<section>
 			<time
-				className="font-semibold text-gray-400 text-xs transition-colors duration-300 sm:text-sm dark:text-gray-600"
+				className="text-gray-400 text-xs transition-colors duration-300 sm:text-sm dark:text-gray-600"
 				role="note"
 			>
-				Last updated at {formattedTimestamp}.
+				{save === "saving" ? "Saving..." : formattedTimestamp}
 			</time>
-
-			{save !== "idle" && (
-				<output className="font-semibold text-gray-400 text-xs transition-colors duration-300 before:content-['_'] sm:text-sm dark:text-gray-600">
-					{save === "saving" && "Saving..."}
-					{save === "saved" && "Saved."}
-				</output>
-			)}
 		</section>
 	);
 };
@@ -74,7 +67,7 @@ const ContentEditor = () => {
 				onChange={({ currentTarget: { value } }) =>
 					setContent(value, Date.now())
 				}
-				placeholder="Start writing, your progress will be automatically stored in your machine's local storage"
+				placeholder="Start writing. Progress saves automatically."
 				readOnly={isFrozen}
 				type="content"
 				value={content}

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,9 +1,9 @@
-import "@fontsource-variable/inter";
+import "@fontsource-variable/inter/wght.css";
 
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import { Toaster } from "sonner";
 import { App } from "~/app";
+import { ThemedToaster } from "~/toaster";
 
 const root = document.getElementById("root");
 if (!root) {
@@ -12,15 +12,7 @@ if (!root) {
 
 createRoot(root).render(
 	<StrictMode>
-		<Toaster
-			closeButton
-			position="bottom-right"
-			toastOptions={{
-				className:
-					"bg-stone-50 dark:bg-stone-900 border-stone-200 dark:border-stone-800 text-stone-900 dark:text-stone-100",
-				duration: 2000,
-			}}
-		/>
+		<ThemedToaster />
 		<App />
 	</StrictMode>,
 );

--- a/app/toaster.tsx
+++ b/app/toaster.tsx
@@ -1,0 +1,19 @@
+import { Toaster } from "sonner";
+import { useDarkTheme } from "./use-dark-mode.ts";
+
+export const ThemedToaster = () => {
+	const { isDark } = useDarkTheme();
+
+	return (
+		<Toaster
+			closeButton
+			position="bottom-right"
+			theme={isDark ? "dark" : "light"}
+			toastOptions={{
+				className:
+					"bg-stone-50 dark:bg-stone-900 border-stone-200 dark:border-stone-800 text-stone-900 dark:text-stone-100",
+				duration: 2000,
+			}}
+		/>
+	);
+};

--- a/app/toaster.tsx
+++ b/app/toaster.tsx
@@ -1,8 +1,8 @@
 import { Toaster } from "sonner";
-import { useDarkTheme } from "./use-dark-mode.ts";
+import { useIsDark } from "./use-dark-mode.ts";
 
 export const ThemedToaster = () => {
-	const { isDark } = useDarkTheme();
+	const isDark = useIsDark();
 
 	return (
 		<Toaster

--- a/app/use-dark-mode.ts
+++ b/app/use-dark-mode.ts
@@ -24,11 +24,18 @@ DarkThemeStore.subscribe((isDark) => {
 });
 
 /**
+ * Lightweight hook that only reads the dark theme state.
+ * Does not register any effects — safe to call from multiple components
+ * without duplicating listeners.
+ */
+export const useIsDark = () => useStore(DarkThemeStore, (state) => state);
+
+/**
  * Hook to use the dark theme. May be upgraded to include other
  * themes in the future.
  */
 export const useDarkTheme = () => {
-	const isDark = useStore(DarkThemeStore, (isDark) => isDark);
+	const isDark = useIsDark();
 
 	// Sync the theme with system preference.
 	useEffect(() => {

--- a/e2e/Speednote.test.tsx
+++ b/e2e/Speednote.test.tsx
@@ -92,11 +92,6 @@ test("renders properly", async ({ page }) => {
 
 	// Sanity checks for markups, check footer and header.
 	await expect(page.getByText("About")).toBeVisible();
-	await expect(
-		page.getByText(
-			"Thank you so much for using Speednote! Made with ♥ in Tokyo, Japan",
-		),
-	).toBeVisible();
 
 	// Should also render a link to GitHub.
 	const linkToSource = page.getByRole("link", { name: "About" });
@@ -176,8 +171,8 @@ test("able to edit title and content", async ({ page }) => {
 		"Today I spent 1000 JPY for lunch at a fish shop",
 	);
 
-	// There should be a date that shows the last updated date as well.
-	await expect(page.getByText(/Last updated at/i)).toBeVisible();
+	// There should be a timestamp showing when the note was last updated.
+	await expect(page.getByRole("note")).toBeVisible();
 });
 
 test("able to clear content and undo clear", async ({ page }) => {
@@ -640,8 +635,8 @@ test("able to restore autosave after hiding the app", async ({ page }) => {
 		document.dispatchEvent(new Event("visibilitychange"));
 	});
 
-	// Verify that the state is still `Saved.`
-	await expect(page.getByRole("status")).toContainText("Saved.");
+	// Verify that the save indicator is no longer in saving state.
+	await expect(page.getByRole("note")).not.toContainText("Saving...");
 
 	// Make the page visible again, and then try again.
 	await page.evaluate(() => {
@@ -656,8 +651,8 @@ test("able to restore autosave after hiding the app", async ({ page }) => {
 	// Fill it out again, and then check if the Autosave still works.
 	await title.fill("Autosave");
 	await content.fill("Autosave");
-	await expect(page.getByRole("status")).toContainText("Saving...");
-	await expect(page.getByRole("status")).toContainText("Saved.");
+	await expect(page.getByRole("note")).toContainText("Saving...");
+	await expect(page.getByRole("note")).not.toContainText("Saving...");
 
 	// Reload the page.
 	await page.reload();

--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
     <noscript>Please enable JavaScript to use Speednote.</noscript>
     <div
       id="root"
-      class="selection:bg-selection selection:text-black dark:bg-linear-to-b bg-gray-50 text-gray-800 transition-colors duration-300 dark:bg-gray-950 dark:text-gray-200"
+      class="selection:bg-selection selection:text-black bg-gray-50 text-gray-800 transition-colors duration-300 dark:bg-stone-900 dark:text-gray-200"
     ></div>
     <script src="/app/index.tsx" type="module"></script>
   </body>

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -25,7 +25,6 @@
 
 		/* Custom */
 		"types": ["vite/client", "vitest/globals", "@testing-library/jest-dom"],
-		"baseUrl": "./",
 		"paths": {
 			"~/*": ["./app/*"]
 		}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
 			devOptions: {
 				enabled: true,
 			},
-			filename: "sw.ts",
+			filename: "sw.js",
 			manifest: {
 				background_color: "#f1c40f",
 				description: "Speednote, the fastest way to put your quick thoughts!",


### PR DESCRIPTION
## Summary

- **Dark mode background**: Changed from `gray-950` (`#030712`) to `stone-900` (`#1c1917`) — near-pure black causes halation/irradiation on light text, making sustained reading fatiguing for users with astigmatism. `stone-900` still passes WCAG AAA (14.13:1 contrast) and closely matches macOS Dark Mode's native tone (`#1c1c1e`).
- **Toast dark mode**: Extracted `Toaster` into a `ThemedToaster` component that reads `useDarkTheme()` and passes the `theme` prop to Sonner — previously Sonner's own CSS variables never flipped to dark regardless of the app's dark mode state.
- **Service worker fix**: Changed `filename: "sw.ts"` to `filename: "sw.js"` in `vite.config.ts` — `vite-plugin-pwa` outputs the file correctly as `sw.js` but uses `filename` verbatim as the registration URL in `registerSW.js`, so the browser was requesting `/sw.ts`, getting the SPA fallback `index.html` (`text/html`), and failing with a MIME type error; the stale SW from a prior successful registration was also the likely cause of intermittent dark-mode-on-load bugs.
- **Metadata simplification**: Collapsed the two-element `<time>` + `<output>` save indicator into a single `<time>` that toggles between `"Saving..."` and the formatted timestamp — removes the redundant "Saved." state (the timestamp itself proves the note was saved); timestamp format changed from verbose full date/time to `dateStyle: "long"` + `timeStyle: "medium"` (e.g. `April 29, 2026, 15:30:45`).
- **Placeholder text**: Shortened from a full instructional sentence to `"Start writing. Progress saves automatically."`.
- **Footer**: Removed the "Thank you" copy, leaving only the version/SHA chip.
- **Content padding**: Tightened the responsive horizontal padding (`sm:px-4 md:px-10 lg:px-20 xl:px-32`) to reduce the overly wide writing surface at large viewports.
- **Dead code**: Removed `dark:bg-linear-to-b` from `index.html` (no `from-*`/`to-*` stops — had no effect) and `baseUrl` from `tsconfig.app.json`.
- **Font import**: Switched from `@fontsource-variable/inter` to the more specific `@fontsource-variable/inter/wght.css` to only load the weight axis.

## Bug fixes

- **Flaky RTL tests** (`able to clear content and undo clear`, `able to freeze notes and unfreeze them`): All async button click handlers (`handleClear`, `handleFreezeNote`, `handleUndo`) are `async` functions that `await onSave()` after their synchronous state updates. On slow CI machines, React's `useSyncExternalStore` subscriber can be scheduled as a microtask rather than flushing inline within `act()`, causing synchronous assertions to run before the DOM update lands. Fixed by replacing `getByRole` + immediate `expect` with `findByRole` / `findByDisplayValue` which retry until the condition is met.
- **Playwright autosave test**: Updated from `getByRole("status")` (targeted the now-removed `<output>` element) to `getByRole("note")`, and replaced `toContainText("Saved.")` with `not.toContainText("Saving...")` to match the new single-element save indicator.