### PR TITLE
Fix desynchronized themes with the initial script load

### DIFF
--- a/app/use-dark-mode.ts
+++ b/app/use-dark-mode.ts
@@ -7,7 +7,7 @@ import { useEffect } from "react";
  * as a state for synchronization if it gets called in other components.
  */
 const DarkThemeStore = createStore(
-	window.matchMedia("(prefers-color-scheme: dark)").matches,
+	document.documentElement.classList.contains("dark"),
 );
 
 /**


### PR DESCRIPTION
We populate the store based on the class that was in `html` to prevent desynchronization of light or dark themes.